### PR TITLE
Docker

### DIFF
--- a/backend/spring/Dockerfile
+++ b/backend/spring/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:17
+WORKDIR /app
+ADD target/workflix-0.0.1-SNAPSHOT.jar workflix-0.0.1-SNAPSHOT.jar.original
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "workflix-0.0.1-SNAPSHOT.jar.original"]
+

--- a/backend/spring/readme_docker.txt
+++ b/backend/spring/readme_docker.txt
@@ -1,0 +1,15 @@
+0 - ./mvnw clean package: crear o actualizar jar
+
+1 - Construir la imagen: docker build -t workflix-app .
+
+2 - Crear el contenedor: docker run --name workflix-container -d workflix-app
+
+3 - Iniciar contenedor docker con mysql local y parametros predefinidos: docker run --name workflix-container --network=host -d workflix-app
+
+4 - Iniciar normalmente: sudo docker start workflix-container
+
+
+Detener contenedor: docker stop workflix-container
+
+Eliminar contenedor: docker rm workflix-container
+


### PR DESCRIPTION
Incorporando docker al proyecto.
Cada developer podrá que generar su contenedor e imagen para correr el back sin necesidad de abrir el ide.